### PR TITLE
Gets the jungle ruins and ivymen acquainted to the new atmos, ivymen nest changes

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungleland_dead_crashedship.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_dead_crashedship.dmm
@@ -1,8 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/lavaland_baseturf,
-/area/ruin/unpowered)
 "b" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -12,16 +8,14 @@
 	},
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/template_noop)
+"c" = (
+/obj/item/stack/rods,
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/template_noop)
 "d" = (
-/obj/machinery/computer{
-	dir = 8
-	},
-/turf/open/floor/plating/lavaland_baseturf,
-/area/template_noop)
-"f" = (
-/obj/structure/table,
-/turf/open/floor/plating/lavaland_baseturf,
-/area/template_noop)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/jungle,
+/area/ruin/unpowered)
 "g" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -35,13 +29,17 @@
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/template_noop)
 "i" = (
-/obj/structure/table_frame,
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/structure/table,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
 "j" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
+"l" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/ruin/unpowered)
 "n" = (
 /obj/structure/table,
 /obj/item/flashlight,
@@ -54,21 +52,30 @@
 /turf/open/floor/plating/lavaland_baseturf,
 /area/template_noop)
 "p" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/lavaland_baseturf,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
 "r" = (
 /turf/closed/wall/mineral/titanium,
 /area/ruin/unpowered)
+"s" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/template_noop)
 "t" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/plating/lavaland_baseturf,
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/template_noop)
+"u" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
 "v" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
 "w" = (
 /obj/structure/flora/tree/dead/jungle,
@@ -79,9 +86,11 @@
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/template_noop)
 "y" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/lavaland_baseturf,
-/area/ruin/unpowered)
+/obj/machinery/computer{
+	dir = 8
+	},
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/template_noop)
 "B" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
@@ -89,34 +98,25 @@
 /turf/open/floor/plating/lavaland_baseturf,
 /area/template_noop)
 "C" = (
-/turf/open/floor/plating/lavaland_baseturf,
-/area/ruin/unpowered)
+/turf/open/floor/plasteel/jungle,
+/area/template_noop)
 "D" = (
 /turf/template_noop,
 /area/template_noop)
-"E" = (
+"F" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/lavaland,
-/area/ruin/unpowered)
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/template_noop)
 "G" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
-"H" = (
-/turf/open/floor/plasteel/lavaland,
-/area/ruin/unpowered)
 "I" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/lavaland_baseturf,
-/area/template_noop)
-"J" = (
-/turf/open/floor/plasteel/lavaland,
-/area/template_noop)
+/turf/open/floor/plasteel/jungle,
+/area/ruin/unpowered)
 "K" = (
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating/lavaland_baseturf,
+/obj/structure/table_frame,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
 "L" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
@@ -124,13 +124,17 @@
 	},
 /turf/open/floor/plating/lavaland_baseturf,
 /area/template_noop)
+"N" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/ruin/unpowered)
 "O" = (
 /turf/open/floor/plating/lavaland_baseturf,
 /area/template_noop)
 "P" = (
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/plating/lavaland_baseturf,
-/area/template_noop)
+/obj/structure/frame/machine,
+/turf/open/floor/plasteel/jungle,
+/area/ruin/unpowered)
 "R" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/plating/lavaland_baseturf,
@@ -139,14 +143,9 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/template_noop)
-"U" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/lavaland,
-/area/ruin/unpowered)
 "V" = (
-/obj/item/stack/rods,
-/turf/open/floor/plating/lavaland_baseturf,
-/area/template_noop)
+/turf/open/floor/plating/jungle_baseturf/dying,
+/area/ruin/unpowered)
 "W" = (
 /turf/closed/wall/mineral/titanium,
 /area/template_noop)
@@ -159,6 +158,10 @@
 "Y" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/template_noop)
+"Z" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/jungle_baseturf/dying,
 /area/template_noop)
 
 (1,1,1) = {"
@@ -209,7 +212,7 @@ D
 D
 h
 h
-p
+G
 h
 h
 h
@@ -251,11 +254,11 @@ D
 "}
 (5,1,1) = {"
 D
-p
+G
 h
 h
 h
-p
+G
 X
 h
 X
@@ -298,12 +301,12 @@ D
 h
 h
 W
-p
+G
 W
 r
 r
 r
-C
+V
 r
 r
 r
@@ -320,13 +323,13 @@ D
 h
 h
 W
-O
-O
+p
+p
 r
-U
-E
-C
-y
+P
+d
+V
+l
 r
 h
 h
@@ -342,16 +345,16 @@ D
 h
 h
 W
-O
-O
-r
-H
-C
-a
-C
-r
 p
 p
+r
+I
+V
+N
+V
+r
+G
+G
 h
 h
 h
@@ -364,16 +367,16 @@ D
 h
 h
 W
-O
 p
+G
 r
-C
-C
-C
-C
-C
-O
+V
+V
+V
+V
+V
 p
+G
 W
 h
 h
@@ -386,16 +389,16 @@ D
 h
 h
 h
+G
 p
-O
 r
 r
 R
 r
 r
 r
+G
 p
-O
 W
 h
 h
@@ -408,16 +411,16 @@ D
 h
 w
 h
+G
+G
 p
 p
-O
-O
-O
-J
-O
-O
-O
-K
+p
+p
+p
+p
+p
+Z
 W
 h
 h
@@ -431,15 +434,15 @@ h
 h
 h
 Y
-O
+p
+G
+G
+Z
+p
+C
 p
 p
-K
-O
-J
-O
-O
-p
+G
 W
 h
 h
@@ -453,15 +456,15 @@ h
 h
 h
 h
-O
 p
-p
-j
+G
+G
+F
 h
-P
+s
 W
-p
-p
+G
+G
 h
 h
 h
@@ -474,16 +477,16 @@ D
 h
 h
 h
-p
-p
+G
+G
 W
-p
-p
+G
+G
 h
-O
+p
 W
-O
-I
+p
+v
 W
 h
 h
@@ -495,17 +498,17 @@ D
 D
 h
 h
+G
+v
+G
+h
 p
-I
 p
 h
-O
-O
 h
-h
-O
-O
-O
+p
+p
+p
 W
 h
 h
@@ -518,16 +521,16 @@ D
 h
 h
 W
-O
 p
+G
 W
-i
+K
 n
-f
-O
-O
-O
-O
+i
+p
+p
+p
+p
 W
 h
 h
@@ -540,17 +543,17 @@ D
 h
 h
 W
-j
-O
-W
-W
-W
-W
-W
-O
+F
 p
-O
+W
+W
+W
+W
+W
 p
+G
+p
+G
 h
 h
 h
@@ -562,16 +565,16 @@ D
 h
 h
 W
-O
-K
-O
-O
-j
 p
-j
+Z
 p
-O
-O
+p
+F
+G
+F
+G
+p
+p
 W
 h
 h
@@ -584,16 +587,16 @@ D
 h
 h
 W
-p
-p
-O
-V
-O
-O
-J
 G
+G
+p
+c
 O
 p
+C
+u
+p
+G
 W
 h
 h
@@ -606,16 +609,16 @@ D
 h
 h
 W
-O
+p
+G
+G
+G
+G
+C
 p
 p
-p
-p
-J
-O
-O
-p
-p
+G
+G
 W
 h
 h
@@ -628,16 +631,16 @@ D
 h
 h
 W
-O
-v
-p
 p
 j
-O
-O
-O
+G
+G
+F
 p
 p
+p
+G
+G
 W
 h
 h
@@ -650,16 +653,16 @@ D
 h
 h
 W
-O
-W
-O
-P
-t
-K
-J
-J
+p
 W
 p
+s
+t
+Z
+C
+C
+W
+G
 W
 h
 h
@@ -675,10 +678,10 @@ h
 h
 W
 W
-O
-O
-O
-j
+p
+p
+p
+F
 W
 W
 h
@@ -697,10 +700,10 @@ h
 h
 h
 W
-J
-j
-d
-O
+C
+F
+y
+p
 W
 h
 h

--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_ivymen_nest.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_ivymen_nest.dmm
@@ -1,31 +1,37 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/rock/wood,
-/area/ruin/unpowered)
-"b" = (
-/turf/open/indestructible/grass,
-/area/ruin/unpowered)
-"c" = (
-/obj/item/malf_upgrade,
-/obj/item/stack/sheet/mineral/mythril{
-	amount = 50
-	},
+/obj/item/weldingtool/experimental,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
+"b" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
+"c" = (
+/obj/item/storage/toolbox/syndicate,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
 "d" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"f" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/science,
+"e" = (
+/obj/item/storage/box/rxglasses,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
+"f" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/flare,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler_refill,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
 "g" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -35,27 +41,29 @@
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
 "i" = (
-/obj/structure/table/wood,
-/obj/item/storage/belt,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/obj/item/flashlight/lantern{
+	on = 1
+	},
+/turf/open/indestructible/grass,
+/area/ruin/unpowered/ivymen)
 "j" = (
 /turf/closed/mineral/ash_rock,
 /area/template_noop)
 "k" = (
-/turf/open/floor/plating/ashplanet/rocky,
-/area/template_noop)
-"l" = (
 /obj/structure/table/wood,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/clothing/head/helmet/roman/legionnaire,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
+"l" = (
+/turf/closed/indestructible/rock/wood,
+/area/ruin/unpowered/ivymen)
 "m" = (
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
 "n" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -69,21 +77,39 @@
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
 "q" = (
-/turf/closed/wall/mineral/wood,
-/area/ruin/unpowered)
-"t" = (
-/obj/item/construction/rcd/loaded,
+/obj/structure/necropolis_gate{
+	name = "ancient gate"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/indestructible/grass,
+/area/ruin/unpowered/ivymen)
+"s" = (
+/obj/item/malf_upgrade,
+/obj/item/stack/sheet/mineral/mythril{
+	amount = 50
+	},
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
+"u" = (
+/obj/item/storage/bag/plants/portaseeder,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
 "v" = (
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/glass/beaker/waterbottle/large,
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/science,
+/obj/item/reagent_containers/glass/bottle/synaptizine,
+/obj/item/reagent_containers/glass/bottle/synaptizine,
+/obj/item/reagent_containers/glass/bottle/synaptizine,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
 "w" = (
-/obj/item/storage/toolbox/syndicate,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/obj/structure/yog_jungle/ivymen,
+/turf/open/indestructible/grass,
+/area/ruin/unpowered/ivymen)
 "x" = (
 /obj/item/seeds/bamboo,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -96,13 +122,16 @@
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
 "A" = (
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/seeds/tower,
+/obj/structure/table/wood,
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/obj/item/clothing/head/helmet/roman/legionnaire,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
+"B" = (
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/template_noop)
 "C" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -120,16 +149,8 @@
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
 "G" = (
-/obj/structure/closet/crate/radiation,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/flare,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler_refill,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/turf/closed/wall/mineral/wood,
+/area/ruin/unpowered/ivymen)
 "H" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -138,29 +159,26 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"J" = (
-/obj/structure/necropolis_gate{
-	name = "ancient gate"
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/indestructible/grass,
-/area/ruin/unpowered)
 "K" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
 "L" = (
-/obj/structure/sink/puddle,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/stack/sheet/mineral/wood,
+/obj/item/seeds/tower,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
-"M" = (
-/obj/item/storage/box/rxglasses,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
 "N" = (
-/obj/item/weldingtool/experimental,
+/obj/structure/table/wood,
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/obj/item/twohanded/spear,
+/obj/item/scythe,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
 "O" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -169,41 +187,32 @@
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
+"Q" = (
+/obj/structure/table/optable,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
 "R" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
 "S" = (
-/obj/structure/yog_jungle/ivymen,
-/turf/open/indestructible/grass,
-/area/ruin/unpowered)
+/obj/structure/sink/puddle,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
 "T" = (
 /obj/item/shovel,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"U" = (
-/obj/structure/table/optable,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
 "V" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/scythe,
+/obj/item/construction/rcd/loaded,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
-"W" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/obj/item/flashlight/lantern,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
 "X" = (
-/obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
+/area/ruin/unpowered/ivymen)
+"Y" = (
+/turf/open/indestructible/grass,
+/area/ruin/unpowered/ivymen)
 "Z" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -213,10 +222,10 @@
 j
 j
 j
-q
-q
-q
-q
+G
+G
+G
+G
 h
 h
 h
@@ -234,11 +243,11 @@ j
 (2,1,1) = {"
 j
 j
-q
-q
-V
-l
-q
+G
+G
+N
+A
+G
 y
 y
 y
@@ -256,16 +265,16 @@ j
 (3,1,1) = {"
 j
 j
-q
-i
-m
-m
-m
-k
-k
-k
-k
-k
+G
+b
+X
+X
+X
+B
+B
+B
+B
+B
 y
 H
 y
@@ -278,16 +287,16 @@ j
 (4,1,1) = {"
 j
 j
-q
-W
-m
-m
-q
+G
+k
+X
+X
+G
 o
 g
 y
 I
-k
+B
 y
 y
 g
@@ -300,16 +309,16 @@ y
 (5,1,1) = {"
 j
 j
-q
-q
-q
-q
-q
+G
+G
+G
+G
+G
 y
 Z
 I
 y
-k
+B
 y
 K
 y
@@ -322,19 +331,19 @@ y
 (6,1,1) = {"
 j
 j
-a
-a
-a
-a
-a
-a
+l
+l
+l
+l
+l
+l
 y
 g
 z
-k
-k
-k
-k
+B
+B
+B
+B
 C
 D
 O
@@ -343,17 +352,17 @@ y
 "}
 (7,1,1) = {"
 j
-a
-a
-a
-a
-a
-a
-a
-a
+l
+l
+l
+l
+l
+l
+l
+l
 y
 y
-k
+B
 y
 y
 y
@@ -365,17 +374,17 @@ y
 "}
 (8,1,1) = {"
 j
-a
-a
-b
-b
-b
-b
-a
-a
+l
+l
+i
+Y
+Y
+Y
+l
+l
 y
 I
-k
+B
 y
 y
 d
@@ -387,17 +396,17 @@ y
 "}
 (9,1,1) = {"
 j
-a
-a
-m
-m
-m
-b
-a
-a
+l
+l
+X
+X
+X
+Y
+l
+l
 y
 y
-k
+B
 g
 y
 y
@@ -409,17 +418,17 @@ j
 "}
 (10,1,1) = {"
 j
-a
-a
-m
-S
-m
-b
-b
-J
-k
-k
-k
+l
+l
+X
+w
+X
+Y
+Y
+q
+B
+B
+B
 y
 y
 E
@@ -431,17 +440,17 @@ j
 "}
 (11,1,1) = {"
 j
-a
-a
-m
-m
-m
-b
-a
-a
+l
+l
+X
+X
+X
+Y
+l
+l
 y
 y
-k
+B
 y
 y
 y
@@ -453,17 +462,17 @@ j
 "}
 (12,1,1) = {"
 j
-a
-a
-b
-b
-b
-b
-a
-a
+l
+l
+i
+Y
+Y
+Y
+l
+l
 g
 y
-k
+B
 y
 H
 y
@@ -475,17 +484,17 @@ y
 "}
 (13,1,1) = {"
 j
-a
-a
-a
-a
-a
-a
-a
-a
+l
+l
+l
+l
+l
+l
+l
+l
 y
 g
-k
+B
 y
 y
 K
@@ -498,16 +507,16 @@ y
 (14,1,1) = {"
 j
 j
-a
-a
-a
-a
-a
-a
+l
+l
+l
+l
+l
+l
 p
 R
 y
-k
+B
 d
 y
 y
@@ -520,19 +529,19 @@ y
 (15,1,1) = {"
 j
 j
-q
-q
-q
-q
-q
-q
+G
+G
+G
+G
+G
+G
 y
 y
 z
-k
-k
-k
-k
+B
+B
+B
+B
 C
 T
 O
@@ -542,16 +551,16 @@ y
 (16,1,1) = {"
 j
 j
-q
-U
-m
+G
+Q
 X
-A
-q
+u
+L
+G
 g
 y
 y
-k
+B
 y
 Z
 y
@@ -564,16 +573,16 @@ y
 (17,1,1) = {"
 j
 j
-q
-w
-m
-N
-f
-q
+G
+c
+X
+a
+v
+G
 y
 y
 y
-k
+B
 y
 g
 y
@@ -586,16 +595,16 @@ j
 (18,1,1) = {"
 j
 j
-q
-c
-M
-t
-m
-m
-k
-k
-k
-k
+G
+s
+e
+V
+X
+X
+B
+B
+B
+B
 y
 y
 y
@@ -608,12 +617,12 @@ j
 (19,1,1) = {"
 j
 j
-q
-q
-v
-L
 G
-q
+G
+m
+S
+f
+G
 y
 y
 y
@@ -631,11 +640,11 @@ j
 j
 j
 j
-q
-q
-q
-q
-q
+G
+G
+G
+G
+G
 h
 h
 h

--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_ivymen_nest.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_ivymen_nest.dmm
@@ -1,27 +1,27 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /obj/item/weldingtool/experimental,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"b" = (
+"ab" = (
 /obj/structure/table/wood,
 /obj/item/storage/belt,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"c" = (
+"ac" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"d" = (
+"ad" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"e" = (
+"ae" = (
 /obj/item/storage/box/rxglasses,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"f" = (
+"af" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
@@ -32,138 +32,108 @@
 /obj/item/hand_labeler_refill,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"g" = (
+"ag" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"h" = (
+"ah" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"i" = (
+"ai" = (
 /obj/item/flashlight/lantern{
 	on = 1
 	},
 /turf/open/indestructible/grass,
 /area/ruin/unpowered/ivymen)
-"j" = (
-/turf/closed/mineral/ash_rock,
-/area/template_noop)
-"k" = (
+"ak" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"l" = (
+"al" = (
 /turf/closed/indestructible/rock/wood,
 /area/ruin/unpowered/ivymen)
-"m" = (
+"am" = (
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"n" = (
+"an" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"o" = (
+"ao" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"p" = (
+"ap" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"q" = (
+"aq" = (
 /obj/structure/necropolis_gate{
 	name = "ancient gate"
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/grass,
 /area/ruin/unpowered/ivymen)
-"s" = (
-/obj/item/malf_upgrade,
-/obj/item/stack/sheet/mineral/mythril{
-	amount = 50
-	},
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered/ivymen)
-"u" = (
+"au" = (
 /obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"v" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/science,
-/obj/item/reagent_containers/glass/bottle/synaptizine,
-/obj/item/reagent_containers/glass/bottle/synaptizine,
-/obj/item/reagent_containers/glass/bottle/synaptizine,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered/ivymen)
-"w" = (
+"aw" = (
 /obj/structure/yog_jungle/ivymen,
 /turf/open/indestructible/grass,
 /area/ruin/unpowered/ivymen)
-"x" = (
+"ax" = (
 /obj/item/seeds/bamboo,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"y" = (
+"ay" = (
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"z" = (
+"az" = (
 /obj/item/flashlight/flare/torch,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"A" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/clothing/head/helmet/roman/legionnaire,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered/ivymen)
-"B" = (
+"aB" = (
 /turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/template_noop)
-"C" = (
+"aC" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"D" = (
+"aD" = (
 /obj/item/cultivator/rake,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"E" = (
+"aE" = (
 /obj/structure/bonfire/dense,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"F" = (
+"aF" = (
 /obj/item/hatchet/wooden,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"G" = (
+"aG" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/unpowered/ivymen)
-"H" = (
+"aH" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"I" = (
+"aI" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"K" = (
+"aK" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"L" = (
+"aL" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/sheet/mineral/wood,
 /obj/item/stack/sheet/mineral/wood,
@@ -171,490 +141,570 @@
 /obj/item/seeds/tower,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"N" = (
-/obj/structure/table/wood,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/twohanded/spear,
-/obj/item/scythe,
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered/ivymen)
-"O" = (
+"aO" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"P" = (
+"aP" = (
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"Q" = (
+"aQ" = (
 /obj/structure/table/optable,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"R" = (
+"aR" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"S" = (
+"aS" = (
 /obj/structure/sink/puddle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"T" = (
+"aT" = (
 /obj/item/shovel,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"V" = (
+"aV" = (
 /obj/item/construction/rcd/loaded,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"X" = (
+"aX" = (
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered/ivymen)
-"Y" = (
+"aY" = (
 /turf/open/indestructible/grass,
 /area/ruin/unpowered/ivymen)
-"Z" = (
+"aZ" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
+"hG" = (
+/obj/item/pickaxe,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"hW" = (
+/obj/item/malf_upgrade,
+/obj/item/stack/sheet/mineral/mythril{
+	amount = 50
+	},
+/obj/structure/closet/crate/wooden,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
+"kJ" = (
+/obj/item/seeds/nettle,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"lS" = (
+/obj/item/seeds/ambrosia,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"mF" = (
+/obj/item/plant_analyzer,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"uo" = (
+/obj/item/flashlight/lantern{
+	on = 1
+	},
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"Ez" = (
+/obj/item/seeds/cotton,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"LK" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/bamboospear,
+/obj/item/twohanded/bamboospear,
+/obj/item/twohanded/bamboospear,
+/obj/item/twohanded/bamboospear,
+/obj/item/hatchet/wooden,
+/obj/item/hatchet/wooden,
+/obj/item/hatchet/wooden,
+/obj/item/scythe,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
+"Ra" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/science,
+/obj/item/reagent_containers/glass/bottle/synaptizine,
+/obj/item/reagent_containers/spray/pestspray,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/l4z,
+/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
+"Tb" = (
+/obj/item/twohanded/bamboospear,
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/template_noop)
+"Uu" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt/quiver/ashwalker{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/quiver/ashwalker{
+	pixel_y = -2
+	},
+/obj/item/gun/ballistic/bow{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/gun/ballistic/bow{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
+"UP" = (
+/turf/closed/mineral/ash_rock/jungle,
+/area/template_noop)
 
 (1,1,1) = {"
-j
-j
-j
-G
-G
-G
-G
-h
-h
-h
-h
-y
-K
-y
-y
-h
-h
-h
-j
-j
+UP
+UP
+UP
+aG
+aG
+aG
+aG
+ah
+ah
+ah
+ah
+ah
+aK
+ay
+ay
+UP
+UP
+UP
+UP
+UP
 "}
 (2,1,1) = {"
-j
-j
-G
-G
-N
-A
-G
-y
-y
-y
-y
-y
-y
-y
-I
-y
-y
-y
-j
-j
+UP
+UP
+aG
+aG
+Uu
+LK
+aG
+ay
+ay
+ay
+ay
+ay
+ay
+ay
+aI
+ay
+ay
+hG
+UP
+UP
 "}
 (3,1,1) = {"
-j
-j
-G
-b
-X
-X
-X
-B
-B
-B
-B
-B
-y
-H
-y
-Z
-y
-y
-R
-j
+UP
+UP
+aG
+ab
+aX
+aX
+aX
+aB
+aB
+aB
+aB
+aB
+ay
+aH
+ay
+aZ
+ay
+ay
+aR
+UP
 "}
 (4,1,1) = {"
-j
-j
-G
-k
-X
-X
-G
-o
-g
-y
-I
-B
-y
-y
-g
-y
-O
-y
-y
-y
+UP
+UP
+aG
+ak
+aX
+aX
+aG
+ao
+ag
+ay
+aI
+aB
+ay
+ay
+ag
+ay
+aO
+ay
+ay
+ay
 "}
 (5,1,1) = {"
-j
-j
-G
-G
-G
-G
-G
-y
-Z
-I
-y
-B
-y
-K
-y
-y
-y
-O
-y
-y
+UP
+UP
+aG
+aG
+aG
+aG
+aG
+ay
+aZ
+aI
+uo
+aB
+ay
+aK
+ay
+ay
+ay
+aO
+ay
+ay
 "}
 (6,1,1) = {"
-j
-j
-l
-l
-l
-l
-l
-l
-y
-g
-z
-B
-B
-B
-B
-C
-D
-O
-y
-y
+UP
+UP
+al
+al
+al
+al
+al
+al
+ay
+ag
+az
+aB
+aB
+aB
+aB
+aC
+aD
+aO
+uo
+UP
 "}
 (7,1,1) = {"
-j
-l
-l
-l
-l
-l
-l
-l
-l
-y
-y
-B
-y
-y
-y
-P
-y
-O
-y
-y
+UP
+al
+al
+al
+al
+al
+al
+al
+al
+ay
+ay
+aB
+Tb
+Ez
+ay
+aP
+ay
+aO
+ay
+UP
 "}
 (8,1,1) = {"
-j
-l
-l
-i
-Y
-Y
-Y
-l
-l
-y
-I
-B
-y
-y
-d
-H
-O
-y
-H
-y
+UP
+al
+al
+ai
+aY
+aY
+aY
+al
+al
+ay
+aI
+aB
+ay
+ay
+ad
+aH
+aO
+ay
+aH
+UP
 "}
 (9,1,1) = {"
-j
-l
-l
-X
-X
-X
-Y
-l
-l
-y
-y
-B
-g
-y
-y
-x
-y
-y
-y
-j
+UP
+al
+al
+aX
+aX
+aX
+aY
+al
+al
+ay
+ay
+aB
+ag
+ay
+ay
+ax
+ay
+ay
+ay
+UP
 "}
 (10,1,1) = {"
-j
-l
-l
-X
-w
-X
-Y
-Y
-q
-B
-B
-B
-y
-y
-E
-F
-y
-n
-y
-j
+UP
+al
+al
+aX
+aw
+aX
+aY
+aY
+aq
+aB
+aB
+aB
+ay
+ay
+aE
+aF
+ay
+an
+ay
+UP
 "}
 (11,1,1) = {"
-j
-l
-l
-X
-X
-X
-Y
-l
-l
-y
-y
-B
-y
-y
-y
-y
-H
-y
-y
-j
+UP
+al
+al
+aX
+aX
+aX
+aY
+al
+al
+ay
+ay
+aB
+ay
+ay
+lS
+ay
+aH
+ay
+ay
+UP
 "}
 (12,1,1) = {"
-j
-l
-l
-i
-Y
-Y
-Y
-l
-l
-g
-y
-B
-y
-H
-y
-y
-y
-y
-y
-y
+UP
+al
+al
+ai
+aY
+aY
+aY
+al
+al
+ag
+ay
+aB
+ay
+aH
+ay
+ay
+mF
+kJ
+ay
+UP
 "}
 (13,1,1) = {"
-j
-l
-l
-l
-l
-l
-l
-l
-l
-y
-g
-B
-y
-y
-K
-y
-O
-y
-y
-y
+UP
+al
+al
+al
+al
+al
+al
+al
+al
+ay
+ag
+aB
+ay
+ay
+aK
+ay
+aO
+ay
+hG
+UP
 "}
 (14,1,1) = {"
-j
-j
-l
-l
-l
-l
-l
-l
-p
-R
-y
-B
-d
-y
-y
-P
-y
-O
-y
-y
+UP
+UP
+al
+al
+al
+al
+al
+al
+ap
+aR
+Tb
+aB
+ad
+ay
+ay
+aP
+ay
+aO
+ay
+UP
 "}
 (15,1,1) = {"
-j
-j
-G
-G
-G
-G
-G
-G
-y
-y
-z
-B
-B
-B
-B
-C
-T
-O
-y
-y
+UP
+UP
+aG
+aG
+aG
+aG
+aG
+aG
+hG
+ay
+az
+aB
+aB
+aB
+aB
+aC
+aT
+aO
+uo
+UP
 "}
 (16,1,1) = {"
-j
-j
-G
-Q
-X
-u
-L
-G
-g
-y
-y
-B
-y
-Z
-y
-y
-y
-O
-y
-y
+UP
+UP
+aG
+aQ
+aX
+au
+aL
+aG
+ag
+ay
+uo
+aB
+ay
+aZ
+ay
+ay
+ax
+aO
+ay
+ay
 "}
 (17,1,1) = {"
-j
-j
-G
-c
-X
-a
-v
-G
-y
-y
-y
-B
-y
-g
-y
-I
-O
-y
-y
-j
+UP
+UP
+aG
+ac
+aX
+aa
+Ra
+aG
+ay
+ay
+ay
+aB
+ay
+ag
+ay
+aI
+aO
+ay
+ay
+UP
 "}
 (18,1,1) = {"
-j
-j
-G
-s
-e
-V
-X
-X
-B
-B
-B
-B
-y
-y
-y
-y
-g
-y
-y
-j
+UP
+UP
+aG
+hW
+ae
+aV
+aX
+aX
+aB
+aB
+aB
+aB
+ay
+ay
+ay
+ay
+ag
+ay
+ay
+UP
 "}
 (19,1,1) = {"
-j
-j
-G
-G
-m
-S
-f
-G
-y
-y
-y
-y
-y
-I
-y
-y
-y
-y
-p
-j
+UP
+UP
+aG
+aG
+am
+aS
+af
+aG
+ay
+ay
+ay
+ay
+ay
+aI
+ay
+ay
+ay
+ay
+ap
+UP
 "}
 (20,1,1) = {"
-j
-j
-j
-G
-G
-G
-G
-G
-h
-h
-h
-h
-y
-y
-y
-h
-h
-h
-j
-j
+UP
+UP
+UP
+aG
+aG
+aG
+aG
+aG
+ah
+ah
+ah
+ah
+ay
+ay
+ay
+ah
+ah
+ah
+UP
+UP
 "}

--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_oldtemple.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_oldtemple.dmm
@@ -3,6 +3,9 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
+"c" = (
+/turf/closed/mineral/ash_rock/jungle,
+/area/ruin/unpowered)
 "d" = (
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
@@ -15,9 +18,6 @@
 	startDead = 1
 	},
 /turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered)
-"j" = (
-/turf/closed/mineral/ash_rock,
 /area/ruin/unpowered)
 "m" = (
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -126,12 +126,12 @@ m
 m
 m
 o
-j
-j
-j
-j
-j
-j
+c
+c
+c
+c
+c
+c
 m
 m
 m
@@ -144,12 +144,12 @@ u
 m
 m
 u
-j
+c
 y
 z
 F
 z
-j
+c
 m
 m
 m
@@ -158,16 +158,16 @@ a
 (4,1,1) = {"
 o
 a
-j
-j
-j
-j
-j
+c
+c
+c
+c
+c
 d
 Q
 Q
 d
-j
+c
 m
 o
 a
@@ -175,8 +175,8 @@ m
 "}
 (5,1,1) = {"
 m
-j
-j
+c
+c
 O
 d
 d
@@ -185,7 +185,7 @@ d
 Q
 Q
 d
-j
+c
 m
 u
 m
@@ -193,7 +193,7 @@ m
 "}
 (6,1,1) = {"
 a
-j
+c
 d
 d
 d
@@ -203,15 +203,15 @@ d
 Q
 Q
 d
-j
-j
+c
+c
 m
 o
 a
 "}
 (7,1,1) = {"
 o
-j
+c
 Q
 Q
 Q
@@ -222,14 +222,14 @@ Q
 Z
 d
 d
-j
+c
 m
 m
 m
 "}
 (8,1,1) = {"
 m
-j
+c
 p
 F
 Q
@@ -247,7 +247,7 @@ o
 "}
 (9,1,1) = {"
 o
-j
+c
 Q
 I
 Q
@@ -265,7 +265,7 @@ m
 "}
 (10,1,1) = {"
 m
-j
+c
 Q
 Q
 Q
@@ -276,14 +276,14 @@ Q
 Q
 d
 d
-j
+c
 a
 m
 u
 "}
 (11,1,1) = {"
 m
-j
+c
 d
 d
 d
@@ -293,16 +293,16 @@ U
 Q
 Q
 d
-j
-j
+c
+c
 m
 m
 m
 "}
 (12,1,1) = {"
 a
-j
-j
+c
+c
 J
 d
 d
@@ -311,7 +311,7 @@ f
 Q
 Q
 h
-j
+c
 u
 m
 a
@@ -320,16 +320,16 @@ m
 (13,1,1) = {"
 o
 m
-j
-j
-j
-j
-j
+c
+c
+c
+c
+c
 d
 Q
 Q
 d
-j
+c
 a
 m
 m
@@ -342,12 +342,12 @@ a
 m
 m
 m
-j
+c
 z
 y
 z
 y
-j
+c
 m
 m
 m
@@ -360,12 +360,12 @@ m
 m
 m
 o
-j
-j
-j
-j
-j
-j
+c
+c
+c
+c
+c
+c
 m
 m
 o

--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_oldtemple.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_oldtemple.dmm
@@ -16,53 +16,40 @@
 	},
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
-"i" = (
-/obj/structure/mineral_door/wood,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
 "j" = (
 /turf/closed/mineral/ash_rock,
 /area/ruin/unpowered)
 "m" = (
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"n" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
 "o" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"r" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/bone,
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
-"t" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/runed_metal,
-/turf/open/floor/plating/ashplanet/rocky,
+"p" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/soulstone,
+/obj/item/clothing/suit/cultrobes,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 "u" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/template_noop)
-"v" = (
-/obj/item/ectoplasm,
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
 "y" = (
-/turf/open/floor/plating/ashplanet/rocky,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/bone,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
-"C" = (
-/obj/effect/decal/remains/human,
+"z" = (
+/obj/structure/table/wood,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/ruin/unpowered)
+"B" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/soulstone,
-/obj/item/clothing/suit/cultrobes,
-/turf/open/floor/plating/ashplanet/rocky,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 "D" = (
 /obj/item/flashlight/flare/torch,
@@ -73,6 +60,16 @@
 /obj/item/clothing/suit/cultrobes,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
+"F" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/runed_metal,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/ruin/unpowered)
+"I" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife/ritual,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/ruin/unpowered)
 "J" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/runed_metal,
@@ -82,23 +79,26 @@
 /mob/living/simple_animal/hostile/yog_jungle/corrupted_dryad,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
-"M" = (
-/obj/structure/table/wood,
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
 "O" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
-"P" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/ritual,
-/turf/open/floor/plating/ashplanet/rocky,
+"Q" = (
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 "U" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered)
+"V" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/ruin/unpowered)
+"Z" = (
+/obj/item/ectoplasm,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -145,10 +145,10 @@ m
 m
 u
 j
-r
-M
-t
-M
+y
+z
+F
+z
 j
 m
 m
@@ -164,8 +164,8 @@ j
 j
 j
 d
-y
-y
+Q
+Q
 d
 j
 m
@@ -182,8 +182,8 @@ d
 d
 O
 d
-y
-y
+Q
+Q
 d
 j
 m
@@ -200,8 +200,8 @@ d
 d
 d
 d
-y
-y
+Q
+Q
 d
 j
 j
@@ -212,14 +212,14 @@ a
 (7,1,1) = {"
 o
 j
-y
-y
-y
+Q
+Q
+Q
 d
 L
 D
-y
-v
+Q
+Z
 d
 d
 j
@@ -230,17 +230,17 @@ m
 (8,1,1) = {"
 m
 j
-C
-t
-y
-y
-y
-y
-y
-y
-n
-y
-i
+p
+F
+Q
+Q
+Q
+Q
+Q
+Q
+B
+Q
+V
 m
 m
 o
@@ -248,17 +248,17 @@ o
 (9,1,1) = {"
 o
 j
-y
-P
-y
-y
-y
-y
-y
-y
-y
-y
-i
+Q
+I
+Q
+Q
+Q
+Q
+Q
+Q
+Q
+Q
+V
 m
 a
 m
@@ -266,14 +266,14 @@ m
 (10,1,1) = {"
 m
 j
-y
-y
-y
+Q
+Q
+Q
 d
 L
 D
-y
-y
+Q
+Q
 d
 d
 j
@@ -290,8 +290,8 @@ d
 d
 d
 U
-y
-y
+Q
+Q
 d
 j
 j
@@ -308,8 +308,8 @@ d
 d
 E
 f
-y
-y
+Q
+Q
 h
 j
 u
@@ -326,8 +326,8 @@ j
 j
 j
 d
-y
-y
+Q
+Q
 d
 j
 a
@@ -343,10 +343,10 @@ m
 m
 m
 j
-M
-r
-M
-r
+z
+y
+z
+y
 j
 m
 m

--- a/_maps/RandomRuins/JungleRuins/jungleland_swamp_drownedburialgrounds.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_swamp_drownedburialgrounds.dmm
@@ -25,17 +25,6 @@
 /obj/item/pickaxe/mini,
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
 /area/template_noop)
-"m" = (
-/obj/structure/closet/crate/coffin/blackcoffin,
-/obj/item/wisp_lantern,
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
-"n" = (
-/obj/item/candle/infinite{
-	lit = 1
-	},
-/turf/open/floor/plating/ashplanet/rocky,
-/area/ruin/unpowered)
 "o" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
@@ -44,8 +33,9 @@
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
 /area/ruin/unpowered)
-"x" = (
-/turf/open/floor/plating/ashplanet/rocky,
+"w" = (
+/mob/living/simple_animal/hostile/skeleton,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 "y" = (
 /obj/structure/table/wood,
@@ -61,9 +51,11 @@
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/water/toxic_pit,
 /area/ruin/unpowered)
-"J" = (
-/mob/living/simple_animal/hostile/skeleton,
-/turf/open/floor/plating/ashplanet/rocky,
+"I" = (
+/obj/item/candle/infinite{
+	lit = 1
+	},
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 "M" = (
 /obj/structure/closet/crate/coffin{
@@ -71,9 +63,17 @@
 	},
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
 /area/ruin/unpowered)
-"T" = (
+"P" = (
 /mob/living/simple_animal/hostile/skeleton/templar,
-/turf/open/floor/plating/ashplanet/rocky,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/ruin/unpowered)
+"V" = (
+/obj/structure/closet/crate/coffin/blackcoffin,
+/obj/item/wisp_lantern,
+/turf/open/floor/plating/ashplanet/rocky/jungle,
+/area/ruin/unpowered)
+"Z" = (
+/turf/open/floor/plating/ashplanet/rocky/jungle,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -157,8 +157,8 @@ a
 a
 a
 o
-x
-x
+Z
+Z
 o
 B
 B
@@ -180,8 +180,8 @@ y
 j
 a
 a
-x
-x
+Z
+Z
 a
 g
 B
@@ -203,8 +203,8 @@ g
 g
 a
 M
-J
-x
+w
+Z
 o
 g
 B
@@ -226,8 +226,8 @@ d
 g
 a
 a
-x
-x
+Z
+Z
 a
 g
 B
@@ -249,8 +249,8 @@ g
 E
 g
 o
-x
-x
+Z
+Z
 o
 g
 g
@@ -272,8 +272,8 @@ g
 g
 g
 a
-x
-x
+Z
+Z
 a
 a
 a
@@ -289,14 +289,14 @@ B
 g
 a
 o
-n
-x
-n
+I
+Z
+I
 g
 g
 o
-x
-x
+Z
+Z
 o
 a
 o
@@ -310,21 +310,21 @@ k
 h
 B
 g
-x
-x
-x
-m
-T
-x
-x
-x
-x
-x
-x
-x
-x
-x
-x
+Z
+Z
+Z
+V
+P
+Z
+Z
+Z
+Z
+Z
+Z
+Z
+Z
+Z
+Z
 B
 z
 z
@@ -335,14 +335,14 @@ B
 a
 a
 M
-n
-x
-n
+I
+Z
+I
 o
 a
 o
-x
-x
+Z
+Z
 o
 a
 o
@@ -364,8 +364,8 @@ a
 a
 a
 a
-x
-x
+Z
+Z
 a
 a
 a
@@ -387,8 +387,8 @@ a
 a
 a
 o
-x
-x
+Z
+Z
 M
 v
 a
@@ -410,8 +410,8 @@ o
 a
 a
 a
-J
-x
+w
+Z
 a
 a
 B
@@ -433,8 +433,8 @@ a
 a
 a
 M
-x
-x
+Z
+Z
 o
 a
 B
@@ -456,8 +456,8 @@ y
 j
 a
 a
-x
-x
+Z
+Z
 a
 a
 B
@@ -479,8 +479,8 @@ g
 g
 a
 o
-x
-x
+Z
+Z
 o
 B
 B

--- a/_maps/RandomRuins/JungleRuins/jungleland_swamp_drownedburialgrounds.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_swamp_drownedburialgrounds.dmm
@@ -29,6 +29,9 @@
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
 /area/ruin/unpowered)
+"q" = (
+/turf/closed/mineral/ash_rock/jungle,
+/area/ruin/unpowered)
 "v" = (
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
@@ -44,9 +47,6 @@
 "z" = (
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
 /area/template_noop)
-"B" = (
-/turf/closed/mineral/ash_rock,
-/area/ruin/unpowered)
 "E" = (
 /mob/living/simple_animal/hostile/skeleton,
 /turf/open/water/toxic_pit,
@@ -125,19 +125,19 @@ z
 (3,1,1) = {"
 h
 h
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
 h
 h
 h
@@ -147,8 +147,8 @@ z
 "}
 (4,1,1) = {"
 h
-B
-B
+q
+q
 g
 a
 a
@@ -160,8 +160,8 @@ o
 Z
 Z
 o
-B
-B
+q
+q
 h
 h
 h
@@ -170,7 +170,7 @@ z
 "}
 (5,1,1) = {"
 h
-B
+q
 a
 g
 g
@@ -184,7 +184,7 @@ Z
 Z
 a
 g
-B
+q
 h
 h
 z
@@ -193,7 +193,7 @@ z
 "}
 (6,1,1) = {"
 h
-B
+q
 a
 g
 g
@@ -207,7 +207,7 @@ w
 Z
 o
 g
-B
+q
 h
 h
 h
@@ -216,7 +216,7 @@ z
 "}
 (7,1,1) = {"
 h
-B
+q
 g
 g
 a
@@ -230,16 +230,16 @@ Z
 Z
 a
 g
-B
-B
-B
+q
+q
+q
 h
 h
 z
 "}
 (8,1,1) = {"
 h
-B
+q
 g
 a
 a
@@ -256,13 +256,13 @@ g
 g
 g
 g
-B
+q
 h
 z
 "}
 (9,1,1) = {"
 h
-B
+q
 g
 a
 a
@@ -279,13 +279,13 @@ a
 a
 g
 g
-B
+q
 h
 z
 "}
 (10,1,1) = {"
 h
-B
+q
 g
 a
 o
@@ -302,13 +302,13 @@ a
 o
 a
 g
-B
+q
 z
 k
 "}
 (11,1,1) = {"
 h
-B
+q
 g
 Z
 Z
@@ -325,13 +325,13 @@ Z
 Z
 Z
 Z
-B
+q
 z
 z
 "}
 (12,1,1) = {"
 h
-B
+q
 a
 a
 M
@@ -348,13 +348,13 @@ a
 o
 a
 o
-B
+q
 z
 z
 "}
 (13,1,1) = {"
 h
-B
+q
 a
 a
 v
@@ -371,13 +371,13 @@ a
 a
 a
 a
-B
+q
 h
 z
 "}
 (14,1,1) = {"
 h
-B
+q
 a
 a
 a
@@ -394,13 +394,13 @@ v
 a
 a
 a
-B
+q
 h
 h
 "}
 (15,1,1) = {"
 h
-B
+q
 a
 a
 a
@@ -414,16 +414,16 @@ w
 Z
 a
 a
-B
-B
-B
+q
+q
+q
 h
 h
 h
 "}
 (16,1,1) = {"
 h
-B
+q
 a
 a
 a
@@ -437,7 +437,7 @@ Z
 Z
 o
 a
-B
+q
 h
 h
 h
@@ -446,7 +446,7 @@ z
 "}
 (17,1,1) = {"
 h
-B
+q
 a
 a
 j
@@ -460,7 +460,7 @@ Z
 Z
 a
 a
-B
+q
 h
 h
 h
@@ -469,8 +469,8 @@ z
 "}
 (18,1,1) = {"
 h
-B
-B
+q
+q
 a
 a
 a
@@ -482,8 +482,8 @@ o
 Z
 Z
 o
-B
-B
+q
+q
 h
 h
 h
@@ -493,19 +493,19 @@ z
 (19,1,1) = {"
 h
 h
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
+q
 h
 h
 h

--- a/_maps/RandomRuins/JungleRuins/jungleland_swamp_farm.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_swamp_farm.dmm
@@ -23,9 +23,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
-"f" = (
-/turf/open/floor/wood/lavaland,
-/area/template_noop)
 "h" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin/empty,
@@ -91,6 +88,9 @@
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/wheat/rice,
 /turf/open/floor/plating/dirt/jungleland/toxic_pit,
+/area/template_noop)
+"D" = (
+/turf/open/floor/wood/jungle,
 /area/template_noop)
 "F" = (
 /obj/structure/table/wood,
@@ -588,12 +588,12 @@ I
 G
 G
 G
-f
-f
-f
-f
-f
-f
+D
+D
+D
+D
+D
+D
 X
 h
 w
@@ -615,12 +615,12 @@ L
 L
 G
 G
-f
-f
-f
-f
-f
-f
+D
+D
+D
+D
+D
+D
 e
 P
 l

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -918,3 +918,9 @@
 	desc = "A tattered dress of white fabric."
 	icon_state = "cheongsam_s"
 	item_state = "cheongsam_s"
+
+//ivymen name variatons
+
+/obj/item/clothing/under/ash_robe/hunter/jungle
+	name = "primal rags"
+	desc = "Light primal rags that are fashionable and practical, while still maximizing photosynthesis capability for plantpeople."

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3372,6 +3372,7 @@
 #include "yogstation\code\game\area\areas\centcom.dm"
 #include "yogstation\code\game\area\areas\holodeck.dm"
 #include "yogstation\code\game\area\areas\shuttles.dm"
+#include "yogstation\code\game\area\areas\ruins\jungleland.dm"
 #include "yogstation\code\game\gamemodes\game_mode.dm"
 #include "yogstation\code\game\gamemodes\objective.dm"
 #include "yogstation\code\game\gamemodes\objective_items.dm"

--- a/yogstation/code/game/area/areas/ruins/jungleland.dm
+++ b/yogstation/code/game/area/areas/ruins/jungleland.dm
@@ -1,0 +1,2 @@
+/area/ruin/unpowered/ivymen
+	icon_state = "red"

--- a/yogstation/code/game/objects/structures/ghost_role_spawners.dm
+++ b/yogstation/code/game/objects/structures/ghost_role_spawners.dm
@@ -290,7 +290,7 @@
 
 /datum/outfit/ivymen
 	name = "Ivyman"
-	uniform = /obj/item/clothing/under/gladiator
+	uniform = /obj/item/clothing/under/ash_robe/hunter/jungle
 
 /datum/outfit/ivymen/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	H.underwear = "Nude"

--- a/yogstation/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/yogstation/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -70,3 +70,6 @@
 
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2
 	icon_state ="darkstairs2_wide"
+
+/turf/open/floor/wood/jungle
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -150,3 +150,8 @@
 
 /turf/open/floor/plasteel/jungle
 	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
+
+/turf/closed/mineral/ash_rock/jungle
+	turf_type = /turf/open/floor/plating/jungle_baseturf
+	baseturfs = /turf/open/floor/plating/jungle_baseturf
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -144,3 +144,9 @@
 
 /turf/open/floor/plating/jungle_baseturf/dying
 	baseturfs = /turf/open/floor/plating/dirt/jungleland/dying_forest
+
+/turf/open/indestructible/grass/jungle
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
+
+/turf/open/floor/plasteel/jungle
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -131,3 +131,16 @@
 	var/chance = ((humie.wear_suit ? 100 - humie.wear_suit.armor.bio : 100)  +  (humie.head ? 100 - humie.head.armor.bio : 100) )/2
 	if(prob(chance * 0.33))
 		humie.apply_status_effect(/datum/status_effect/toxic_buildup)
+
+/turf/open/floor/wood/jungle
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
+
+/turf/open/floor/plating/ashplanet/rocky/jungle
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
+
+/turf/open/floor/plating/jungle_baseturf
+	baseturfs = /turf/open/floor/plating/dirt/jungleland/jungle
+	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
+
+/turf/open/floor/plating/jungle_baseturf/dying
+	baseturfs = /turf/open/floor/plating/dirt/jungleland/dying_forest

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -288,14 +288,14 @@
 	speedmod = 0
 	mutantlungs = /obj/item/organ/lungs/ashwalker/ivymen
 	breathid = "n2" // yogs end
-	disliked_food = DAIRY | MICE
+	disliked_food = DAIRY
 
 /datum/species/lizard/ivymen/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
-	C.weather_immunities |= "ash"
+	C.weather_immunities |= "acid"
 
 /datum/species/lizard/ivymen/on_species_loss(mob/living/carbon/C)
 	. = ..()
-	C.weather_immunities -= "ash"
+	C.weather_immunities -= "acid"
 
 #undef STATUS_MESSAGE_COOLDOWN

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -282,12 +282,14 @@
  Podpeople subspecies: IVYMEN
 */
 /datum/species/pod/ivymen
-	// A unique podpeople mutation native to Jungleland. They are adapted to the region, don't mind meat, and move faster than normal podpeople, but lack the ability to use guns.
+	// A unique podpeople mutation native to Jungleland. 
+	// They are adapted to the region, don't mind meat, and move faster than normal podpeople.
+	// However, they can't use guns or machines.
 	name = "Ivymen"
 	inherent_traits = list(TRAIT_NOGUNS)
 	speedmod = 0
 	mutantlungs = /obj/item/organ/lungs/ashwalker/ivymen
-	breathid = "n2" // yogs end
+	breathid = "n2"
 	disliked_food = DAIRY
 
 /datum/species/lizard/ivymen/on_species_gain(mob/living/carbon/C, datum/species/old_species)

--- a/yogstation/code/modules/surgery/organs/lungs.dm
+++ b/yogstation/code/modules/surgery/organs/lungs.dm
@@ -14,4 +14,8 @@
 	gas_stimulation_min = 0.002
 
 /obj/item/organ/lungs/ashwalker/ivymen
-	desc = "These lungs appear to be covered in a symbiotic fungus that allows ivymen to breath n2o."
+	desc = "These lungs appear to be covered in a symbiotic fungus that allows ivymen to breath n2o as well as handle higher temperatures."
+	heat_level_1_threshold = 550
+	heat_level_2_threshold = 600
+	heat_level_3_threshold = 1100
+


### PR DESCRIPTION
title

Fixes all the atmos in the ruins to the new jungle atmos.
Ivymen's lungs can now naturally handle the higher jungleland temperature, and they're acidrain proof.
Ivymen get snazyy outfits.
Their nest also comes with bamboo spears instead of glass ones, more lanterns (due to night time), and some more seeds and stuff.

# Changelog

:cl:  
tweak: gets jungle ruins acquainted to the new atmos, ivy men fixes.
/:cl:
