### PR TITLE
adds wasps (yellowjackets) to jungleland

### DIFF
--- a/yogstation/code/datums/mapgen/biomes/JungleBiomes.dm
+++ b/yogstation/code/datums/mapgen/biomes/JungleBiomes.dm
@@ -88,6 +88,6 @@
 	dense_flora = list(/obj/structure/flora/tree/jungle/small = 2,/obj/structure/flora/tree/jungle = 2, /obj/structure/flora/rock/jungle = 1, /obj/structure/flora/junglebush = 1, /obj/structure/flora/junglebush/b = 1, /obj/structure/flora/junglebush/c = 1, /obj/structure/flora/junglebush/large = 1, /obj/structure/flora/rock/pile/largejungle = 1)
 	loose_flora = list(/obj/structure/flora/grass/jungle = 3,/obj/structure/flora/grass/jungle/b = 2,/obj/structure/flora/ausbushes = 2,/obj/structure/flora/ausbushes/leafybush = 1,/obj/structure/flora/ausbushes/sparsegrass = 1,/obj/structure/flora/ausbushes/fullgrass = 1,/obj/structure/herb/explosive_shrooms = 0.1,/obj/structure/herb/cinchona = 0.1,/obj/structure/herb/liberal_hats = 0.1,/obj/structure/flytrap = 0.1)
 	loose_flora_density = 60
-	fauna_types = list(/mob/living/simple_animal/hostile/yog_jungle/blobby = 10 ,/mob/living/simple_animal/hostile/yog_jungle/dryad = 69 ,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 20)
+	fauna_types = list(/mob/living/simple_animal/hostile/yog_jungle/dryad = 69 ,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 20, /mob/living/simple_animal/hostile/yog_jungle/yellowjacket = 10)
 	fauna_density = 0.7
 	this_area = /area/jungleland/proper

--- a/yogstation/code/modules/jungleland/jungle_items.dm
+++ b/yogstation/code/modules/jungleland/jungle_items.dm
@@ -206,14 +206,14 @@
 	grind_results = list(/datum/reagent/toxin/meduracha = 5)
 
 /obj/item/stinger 
-	name = "giant mosquito stinger"
-	desc = "a stinger of a giant exotic mosquito, quite sharp"
+	name = "giant insect stinger"
+	desc = "a stinger of a giant exotic insect, quite sharp"
 	icon = 'yogstation/icons/obj/jungle.dmi'
 	icon_state = "stinger"
 
 /obj/item/melee/stinger_sword
 	name = "stinger sword"
-	desc = "a sword made out of giant mosquito stinger crudely glued to a metal rod"
+	desc = "a sword made out of giant insect stinger crudely glued to a metal rod"
 	force = 15
 	armour_penetration = 75
 	icon = 'yogstation/icons/obj/jungle.dmi'

--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -464,8 +464,8 @@
 	maxHealth = 160
 	health = 160
 	environment_smash = ENVIRONMENT_SMASH_NONE //held off by walls and windows, stupid oversized bee
-	melee_damage_lower = 12  //not that lethal, but it'll catch up to you easily
-	melee_damage_upper = 12
+	melee_damage_lower = 10  //not that lethal, but it'll catch up to you easily
+	melee_damage_upper = 10
 	attacktext = "stings"
 	attack_sound = 'sound/voice/moth/scream_moth.ogg'
 	deathmessage = "rolls over, falling to the ground."

--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -443,6 +443,90 @@
 		awoke = TRUE 
 		icon_state = has_blood ? "mosquito_blood" : icon_living
 
+//jungle version of the wasp. Slightly weaker and faster, with different loot. Renamed to avoid confusion. Credit to original creator.
+/mob/living/simple_animal/hostile/yog_jungle/yellowjacket
+	name = "yellow jacket"
+	desc = "A large and aggressive creature with a massive stinger."
+	icon = 'icons/mob/jungle/wasp.dmi'
+	icon_state = "wasp"
+	icon_living = "wasp"
+	icon_dead = "wasp_dead"
+	icon_gib = "syndicate_gib"
+	move_to_delay = 6
+	movement_type = FLYING
+	ranged = 1
+	ranged_cooldown_time = 120
+	speak_emote = list("buzzes")
+	vision_range = 5
+	aggro_vision_range = 9
+	see_in_dark = 7
+	speed = 2
+	maxHealth = 160
+	health = 160
+	environment_smash = ENVIRONMENT_SMASH_NONE //held off by walls and windows, stupid oversized bee
+	melee_damage_lower = 12  //not that lethal, but it'll catch up to you easily
+	melee_damage_upper = 12
+	attacktext = "stings"
+	attack_sound = 'sound/voice/moth/scream_moth.ogg'
+	deathmessage = "rolls over, falling to the ground."
+	gold_core_spawnable = HOSTILE_SPAWN
+	butcher_results = list(/obj/item/stinger = 1)
+	loot = list()
+	var/charging = FALSE
+	var/revving_charge = FALSE
+	var/poison_type = /datum/reagent/toxin/venom
+	var/poison_per_attack = 5
+
+/mob/living/simple_animal/hostile/yog_jungle/yellowjacket/AttackingTarget()
+	..()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(target.reagents)
+			L.reagents.add_reagent(poison_type, poison_per_attack)
+
+/mob/living/simple_animal/hostile/yog_jungle/yellowjacket/OpenFire()
+	if(charging)
+		return
+	var/tturf = get_turf(target)
+	if(!isturf(tturf))
+		return
+	if(get_dist(src, target) <= 7)
+		charge()
+		ranged_cooldown = world.time + ranged_cooldown_time
+
+/mob/living/simple_animal/hostile/yog_jungle/yellowjacket/Aggro()
+	vision_range = aggro_vision_range
+
+/mob/living/simple_animal/hostile/yog_jungle/yellowjacket/proc/charge(var/atom/chargeat = target, var/delay = 5)
+	if(!chargeat)
+		return
+	var/chargeturf = get_turf(chargeat)
+	if(!chargeturf)
+		return
+	var/dir = get_dir(src, chargeturf)
+	var/turf/T = get_ranged_target_turf(chargeturf, dir, 2)
+	if(!T)
+		return
+	charging = TRUE
+	revving_charge = TRUE
+	do_alert_animation(src)
+	walk(src, 0)
+	setDir(dir)
+	SLEEP_CHECK_DEATH(delay)
+	revving_charge = FALSE
+	var/movespeed = 1
+	walk_towards(src, T, movespeed)
+	SLEEP_CHECK_DEATH(get_dist(src, T) * movespeed)
+	walk(src, 0) // cancel the movement
+	charging = FALSE
+
+/mob/living/simple_animal/hostile/yog_jungle/yellowjacket/Move()
+	if(revving_charge)
+		return FALSE
+	if(charging)
+		DestroySurroundings() //"Fred, were you feeding steroids to the wasp again?"
+	..()
+
 
 /mob/living/simple_animal/hostile/tar 
 	icon = 'yogstation/icons/mob/jungle.dmi'

--- a/yogstation/code/modules/jungleland/jungle_structures.dm
+++ b/yogstation/code/modules/jungleland/jungle_structures.dm
@@ -353,10 +353,10 @@ GLOBAL_LIST_INIT(nests, list())
 	monster.color = "#c30505"
 
 /obj/structure/spawner/nest/jungle
-	possible_mob_types = list(/mob/living/simple_animal/hostile/yog_jungle/blobby,/mob/living/simple_animal/hostile/yog_jungle/dryad)
+	possible_mob_types = list(/mob/living/simple_animal/hostile/yog_jungle/dryad, /mob/living/simple_animal/hostile/yog_jungle/yellowjacket)
 
 /obj/structure/spawner/nest/swamp
-	possible_mob_types = list(/mob/living/simple_animal/hostile/yog_jungle/mosquito,/mob/living/simple_animal/hostile/yog_jungle/meduracha)
+	possible_mob_types = list(/mob/living/simple_animal/hostile/yog_jungle/mosquito,/mob/living/simple_animal/hostile/yog_jungle/meduracha, /mob/living/simple_animal/hostile/yog_jungle/blobby)
 
 /obj/structure/spawner/nest/dying
 	possible_mob_types = list(/mob/living/simple_animal/hostile/yog_jungle/corrupted_dryad,/mob/living/simple_animal/hostile/yog_jungle/skin_twister)

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -171,13 +171,13 @@
 
 /turf/open/water/toxic_pit/Entered(atom/movable/AM)
 	. = ..()
+	var/mob/living/carbon/human/humie = AM
 	if(AM.movement_type & (FLYING|FLOATING) || !AM.has_gravity())
 		return
 	if(HAS_TRAIT(humie,TRAIT_TOXIMMUNE) || HAS_TRAIT(humie,TRAIT_TOXINLOVER))
 		return
 	if(!ishuman(AM))
 		return
-	var/mob/living/carbon/human/humie = AM
 	var/chance = ((humie.wear_suit ? 100 - humie.wear_suit.armor.bio : 100)  +  (humie.head ? 100 - humie.head.armor.bio : 100) )/2
 	if(prob(chance * 0.33))
 		humie.apply_status_effect(/datum/status_effect/toxic_buildup)


### PR DESCRIPTION
first, renames mosquito stingers to insect stingers, because yellowjackets will now also drop stingers.

Second, adds yellow jackets, which are renamed wasps (to avoid confusion), with less HP and damage, more speed, and they  drop a stinger on butcher instead of their other loot.

Yellow jackets replace blobbies in the jungle and jungle nests, and blobbies are moved to swamp nests, and now only spawn in the swamp.

Wasps dont have a very fitting sprite (too lazy and not good enough to make my own) which is too bright and cartoonish for jungleland, but they do have an interesting enough attack, and a big complaint of jungleland is that the mobs attack in pretty boring ways.