### PR TITLE
nerfs corrupted core

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_status_effects.dm
+++ b/yogstation/code/modules/jungleland/jungle_status_effects.dm
@@ -143,7 +143,10 @@
 	. = ..()
 	initial_health = owner.maxHealth
 	owner.setMaxHealth(initial_health * health_multiplier)
-	owner.fully_heal()
+	owner.adjustBruteLoss(-50)
+	owner.adjustFireLoss(-50)
+	owner.remove_CC()
+	owner.bodytemperature = BODYTEMP_NORMAL
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, id)
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "corruption", /datum/mood_event/corrupted_dryad)
 

--- a/yogstation/code/modules/jungleland/jungle_status_effects.dm
+++ b/yogstation/code/modules/jungleland/jungle_status_effects.dm
@@ -133,7 +133,7 @@
 
 /datum/status_effect/corrupted_dryad
 	id = "corrupted_dryad"
-	duration = 60 SECONDS
+	duration = 80 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /obj/screen/alert/status_effect/corrupted_dryad
 	var/health_multiplier = 1.5

--- a/yogstation/code/modules/jungleland/jungle_status_effects.dm
+++ b/yogstation/code/modules/jungleland/jungle_status_effects.dm
@@ -133,10 +133,10 @@
 
 /datum/status_effect/corrupted_dryad
 	id = "corrupted_dryad"
-	duration = 180 SECONDS
+	duration = 60 SECONDS
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /obj/screen/alert/status_effect/corrupted_dryad
-	var/health_multiplier = 2
+	var/health_multiplier = 1.5
 	var/initial_health = 100
 
 /datum/status_effect/corrupted_dryad/on_apply()
@@ -160,7 +160,7 @@
 
 /obj/screen/alert/status_effect/corrupted_dryad
 	name = "Corruption of the forest"
-	desc = "Your heart beats unnaturally strongs, you feel empowered, but nothing is bound to last..."
+	desc = "Your heart beats unnaturally strong, you feel empowered, but nothing is bound to last..."
 	icon = 'yogstation/icons/mob/screen_alert.dmi'
 	icon_state = "rage"
 


### PR DESCRIPTION
corrupted cores last 3 minutes, give slowdown immunity, fullheal on use, and will temporarily double your max health on use. This is obscenely powerful.

Tones it down to last 80 seconds, and it will temporarily increase your max health by 50% instead. In addition, it no longer full heals, but will still heal double the amount a normal core heals. (so -50 brute and -50 burn damage).
