### PR TITLE
Alpha skintwister damage nerf

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -11,6 +11,7 @@
 	maxbodytemp = INFINITY
 	pressure_resistance = 100
 	mob_size = MOB_SIZE_LARGE
+	var/alpha_damage_boost = 1 //if a mob has really high damage it may be unfair to boost it further when making an alpha version.
 
 /mob/living/simple_animal/hostile/yog_jungle/attacked_by(obj/item/I, mob/living/user)
 	if(stat == CONSCIOUS && AIStatus != AI_OFF && !client && user)
@@ -174,6 +175,7 @@
 	melee_damage_upper = 55 // ouch
 	rapid_melee = 2
 	butcher_results = list(/obj/item/stack/sheet/skin_twister = 2)
+	alpha_damage_boost = 0 // 30-55 damage is too much to be boosts by 50%
 	var/human_lure = FALSE
 	var/obj/item/encryptionkey/lure_encryption_key
 	var/victim_ref

--- a/yogstation/code/modules/jungleland/jungle_structures.dm
+++ b/yogstation/code/modules/jungleland/jungle_structures.dm
@@ -344,8 +344,9 @@ GLOBAL_LIST_INIT(nests, list())
 	monster.setMaxHealth(monster.maxHealth * 1.5)
 	monster.health = monster.maxHealth * 1.5
 	monster.move_to_delay = max(monster.move_to_delay / 2, 1)
-	monster.melee_damage_lower *= 1.5 
-	monster.melee_damage_upper *= 1.5
+	if(monster.alpha_damage_boost == 1) //mobs with really high damage amounts may be exempt from giant damage boosts
+		monster.melee_damage_lower *= 1.5 
+		monster.melee_damage_upper *= 1.5
 	monster.faction = list("mining")
 	var/matrix/M = matrix()
 	M.Scale(1.5,1.5)


### PR DESCRIPTION
adds a variable that lets you determine if a specific jungleland mob should get a damage boost from being the enraged/mother/alpha spawn of a nest. 

For now, everyone gets it except skintwisters, which no longer get the 1.5x damage boost since alpha skin twisters are really bonkers, tending to catch people off guard and kill armored miners in 2 hits.