### PR TITLE
slightly lower mob density, slightly higher chance of emerald spiders

### DIFF
--- a/yogstation/code/datums/mapgen/biomes/JungleBiomes.dm
+++ b/yogstation/code/datums/mapgen/biomes/JungleBiomes.dm
@@ -55,7 +55,7 @@
 	loose_flora = list(/obj/structure/flora/ausbushes/stalkybush = 2,/obj/structure/flora/rock = 2,/obj/structure/flora/rock/jungle = 2,/obj/structure/flora/rock/pile = 2,/obj/structure/flora/stump=2,/obj/structure/flora/tree/jungle = 1,/obj/structure/herb/cinchona = 0.1, /obj/structure/flytrap = 0.1)
 	dense_flora_density = 10
 	loose_flora_density = 10
-	fauna_types = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast = 39,/mob/living/simple_animal/hostile/asteroid/goldgrub = 31,/mob/living/simple_animal/hostile/yog_jungle/meduracha = 10,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 16, /mob/living/simple_animal/hostile/yog_jungle/emeraldspider = 3)
+	fauna_types = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast = 39,/mob/living/simple_animal/hostile/asteroid/goldgrub = 31,/mob/living/simple_animal/hostile/yog_jungle/meduracha = 8,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 13, /mob/living/simple_animal/hostile/yog_jungle/emeraldspider = 8)
 	fauna_density = 0.4
 	spawn_fauna_on_closed = TRUE
 	this_area = /area/jungleland/dry_swamp
@@ -68,7 +68,7 @@
 	loose_flora_density = 15
 	dense_flora_density = 10
 	fauna_types = list(/mob/living/simple_animal/hostile/yog_jungle/blobby = 20,/mob/living/simple_animal/hostile/yog_jungle/meduracha = 50,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 2,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 46, /mob/living/simple_animal/hostile/yog_jungle/emeraldspider = 2)
-	fauna_density = 0.75
+	fauna_density = 0.7
 	spawn_fauna_on_closed = TRUE
 	this_area = /area/jungleland/toxic_pit
 
@@ -78,7 +78,7 @@
 	dense_flora = list(/obj/structure/flora/stump=1,/obj/structure/flora/tree/dead/jungle = 2,/obj/structure/flora/rock/jungle = 2,/obj/structure/flora/rock/pile = 2,/obj/structure/flora/rock = 2,/obj/structure/flora/tree/jungle/small = 1,/obj/structure/herb/cinchona = 0.1)
 	dense_flora_density = 70
 	fauna_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/magmawing = 39,/mob/living/simple_animal/hostile/yog_jungle/corrupted_dryad = 55,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 5)
-	fauna_density = 0.85
+	fauna_density = 0.8
 	this_area = /area/jungleland/dying_forest
 
 /datum/biome/jungleland/jungle
@@ -88,6 +88,6 @@
 	dense_flora = list(/obj/structure/flora/tree/jungle/small = 2,/obj/structure/flora/tree/jungle = 2, /obj/structure/flora/rock/jungle = 1, /obj/structure/flora/junglebush = 1, /obj/structure/flora/junglebush/b = 1, /obj/structure/flora/junglebush/c = 1, /obj/structure/flora/junglebush/large = 1, /obj/structure/flora/rock/pile/largejungle = 1)
 	loose_flora = list(/obj/structure/flora/grass/jungle = 3,/obj/structure/flora/grass/jungle/b = 2,/obj/structure/flora/ausbushes = 2,/obj/structure/flora/ausbushes/leafybush = 1,/obj/structure/flora/ausbushes/sparsegrass = 1,/obj/structure/flora/ausbushes/fullgrass = 1,/obj/structure/herb/explosive_shrooms = 0.1,/obj/structure/herb/cinchona = 0.1,/obj/structure/herb/liberal_hats = 0.1,/obj/structure/flytrap = 0.1)
 	loose_flora_density = 60
-	fauna_types = list(/mob/living/simple_animal/hostile/yog_jungle/dryad = 69 ,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 10, /mob/living/simple_animal/hostile/yog_jungle/yellowjacket = 10, /mob/living/simple_animal/hostile/yog_jungle/emeraldspider = 10)
-	fauna_density = 0.7
+	fauna_types = list(/mob/living/simple_animal/hostile/yog_jungle/dryad = 65 ,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1,/mob/living/simple_animal/hostile/yog_jungle/mosquito = 10, /mob/living/simple_animal/hostile/yog_jungle/yellowjacket = 10, /mob/living/simple_animal/hostile/yog_jungle/emeraldspider = 14)
+	fauna_density = 0.65
 	this_area = /area/jungleland/proper

--- a/yogstation/code/datums/mapgen/biomes/JungleBiomes.dm
+++ b/yogstation/code/datums/mapgen/biomes/JungleBiomes.dm
@@ -45,7 +45,7 @@
 	loose_flora_density = 10
 	cellular_noise_map_id = LOW_DENSITY
 	fauna_density = 0.5 
-	fauna_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random = 33,/mob/living/simple_animal/hostile/asteroid/goliath/beast = 33,/mob/living/simple_animal/hostile/asteroid/goldgrub = 32,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1)
+	fauna_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/random = 33,/mob/living/simple_animal/hostile/asteroid/goliath/beast = 33,/mob/living/simple_animal/hostile/asteroid/goldgrub = 25,/mob/living/simple_animal/hostile/yog_jungle/skin_twister = 1, /mob/living/simple_animal/hostile/asteroid/marrowweaver = 7)
 	this_area = /area/jungleland/barren_rocks
 
 /datum/biome/jungleland/dry_swamp


### PR DESCRIPTION
slightly lowers the mob density of the deep jungle, corrupted jungle, and swamp, since they can be a bit too chock full of mobs when combined with nests. Also slightly increase the chance of finding emerald spiders to balance out the lower density, along with adding a small chance to find normal marrow weavers in the barren rocks biome, with both things being so you can still get an adequate amount of weaver chitin.