### PR TITLE
ivymen egg balancing

### DIFF
--- a/yogstation/code/modules/ruins/ivymen_den.dm
+++ b/yogstation/code/modules/ruins/ivymen_den.dm
@@ -1,4 +1,4 @@
-#define IVYMEN_SPAWN_THRESHOLD 2
+#define IVYMEN_SPAWN_THRESHOLD 3 //increased by 1 to account for extra jungle fauna
 //The ivymen nest is basically a rethemed ashwalker nest, takes corpses and makes eggs
 /obj/structure/yog_jungle/ivymen
 	name = "mother tree nest"
@@ -15,7 +15,7 @@
 
 
 	var/faction = list("ivymen")
-	var/meat_counter = 6
+	var/meat_counter = 12 // 4 spawns. One extra to account for the dangerousness of the jungle.
 	var/datum/team/ivymen/ivy
 
 /obj/structure/yog_jungle/ivymen/Initialize()


### PR DESCRIPTION
ivymen now need 3 sacrifices instead of 2 for an extra egg, to account for it being easier to acquire corpses on jungleland.

However, they also start with 4 eggs instead of 3 now (and including the corpses that spawn there already, they just need 1 more corpse for a 5th), because of how dangerous jungleland can be to the unprepared, so that they're not snuffed out early.