### PR TITLE
fix some ivymen stuff

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_ivymen_nest.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_ivymen_nest.dmm
@@ -225,6 +225,24 @@
 "Ad" = (
 /turf/closed/mineral/ash_rock/jungle/deepjungle,
 /area/jungleland/explored)
+"AZ" = (
+/obj/structure/table/wood,
+/obj/item/storage/belt/quiver/weaver/ashwalker{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/quiver/weaver/ashwalker{
+	pixel_y = -2
+	},
+/obj/item/gun/ballistic/bow{
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/obj/item/gun/ballistic/bow{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/turf/open/floor/plating/dirt/jungleland/jungle,
+/area/ruin/unpowered/ivymen)
 "Ez" = (
 /obj/item/seeds/cotton,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -262,24 +280,6 @@
 /obj/item/twohanded/bamboospear,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/jungleland/explored)
-"Uu" = (
-/obj/structure/table/wood,
-/obj/item/storage/belt/quiver/ashwalker{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/quiver/ashwalker{
-	pixel_y = -2
-	},
-/obj/item/gun/ballistic/bow{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/gun/ballistic/bow{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/turf/open/floor/plating/dirt/jungleland/jungle,
-/area/ruin/unpowered/ivymen)
 
 (1,1,1) = {"
 Ad
@@ -308,7 +308,7 @@ Ad
 Ad
 aG
 aG
-Uu
+AZ
 LK
 aG
 ay

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -360,8 +360,7 @@
 	limbs_id = "pod"
 	inherent_traits = list(TRAIT_NOGUNS,TRAIT_RESISTHIGHPRESSURE)
 	speedmod = 0
-	mutantlungs = /obj/item/organ/lungs/ashwalker/ivymen
-	breathid = "n2"
+	mutantlungs = /obj/item/organ/lungs/plant/ivymen
 	disliked_food = DAIRY
 
 /datum/species/pod/ivymen/on_species_gain(mob/living/carbon/C, datum/species/old_species)

--- a/yogstation/code/modules/surgery/organs/lungs.dm
+++ b/yogstation/code/modules/surgery/organs/lungs.dm
@@ -37,8 +37,8 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/medicine/salbutamol = 5)
 	foodtype = VEGETABLES | FRUIT
 
-/obj/item/organ/lungs/ashwalker/ivymen
-	desc = "These lungs appear to be covered in a symbiotic fungus that allows ivymen to breath n2o as well as handle higher temperatures."
+/obj/item/organ/lungs/plant/ivymen
+	desc = "These lungs appear to be covered in a symbiotic fungus that allows ivymen to handle higher temperatures."
 	heat_level_1_threshold = 550
 	heat_level_2_threshold = 600
 	heat_level_3_threshold = 1100


### PR DESCRIPTION
lets ivymen properly breathe jungleland air by swapping their lungs aroound

replaces the quivers that were broken and turned into errors with functional ones in the ivymen nest

they still take slight burn damage every once in a while but i dont know how to fix it without giving them total heat resistance, and its not game breaking since they'll still heal it naturally.
