### PR TITLE
gems, loot changes, and electrified core nerf

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_alpha_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_alpha_mobs.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/yog_jungle/alpha_meduracha
 	name ="Meduracha majora"
-	desc = "Collosal beast of tentacles, its deep eye look directly at you"
+	desc = "Collosal beast of tentacles, its deep eye looks directly at you."
 	icon_state = "alpha_meduracha"
 	icon_living = "alpha_meduracha"
 	icon_dead = "alpha_meduracha_dead"
@@ -12,7 +12,7 @@
 	speak_chance = 1
 	taunt_chance = 1
 	move_to_delay = 7
-	butcher_results = list(/obj/item/stack/sheet/meduracha = 5)
+	butcher_results = list(/obj/item/stack/sheet/meduracha = 5, /obj/item/gem/emerald = 2)
 	faction = list("mining")
 	response_help  = "gently pokes"
 	response_disarm = "gently pushes aside"
@@ -105,7 +105,7 @@
 	pixel_x = -16
 	pixel_y = -16
 	move_to_delay = 5
-	loot  = list(/obj/item/stack/sheet/slime = 10)
+	loot  = list(/obj/item/stack/sheet/slime = 10, /obj/item/gem/emerald = 2)
 	melee_damage_lower = 30
 	melee_damage_upper = 40
 	crusher_loot = /obj/item/crusher_trophy/jungleland/blob_brain
@@ -131,7 +131,7 @@
 
 /mob/living/simple_animal/hostile/yog_jungle/alpha_dryad
 	name ="Wrath of Gaia"
-	desc = "Collosal tree inhabited by all the furiours spirits of the jungle."
+	desc = "Collosal tree inhabited by all the furious spirits of the jungle."
 	icon = 'yogstation/icons/mob/jungle96x96.dmi'
 	icon_state = "wrath_of_gaia"
 	icon_living = "wrath_of_gaia"
@@ -144,7 +144,7 @@
 	maxHealth = 500
 	health = 500
 	crusher_loot = /obj/item/crusher_trophy/jungleland/dryad_branch
-	loot = list(/obj/item/organ/regenerative_core/dryad = 5)
+	loot = list(/obj/item/organ/regenerative_core/dryad = 5, /obj/item/gem/emerald = 2)
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	ranged = TRUE 
@@ -176,7 +176,7 @@
 	maxHealth = 500
 	health = 500
 	crusher_loot = /obj/item/crusher_trophy/jungleland/corrupted_dryad_branch
-	loot = list(/obj/item/organ/regenerative_core/dryad/corrupted = 5)
+	loot = list(/obj/item/organ/regenerative_core/dryad/corrupted = 5, /obj/item/gem/emerald = 2)
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	ranged = TRUE 
@@ -234,7 +234,7 @@
 	maxHealth = 350
 	health = 350
 	crusher_loot = /obj/item/crusher_trophy/jungleland/corrupted_dryad_branch
-	loot = list(/obj/item/stinger = 1)
+	butcher_results = list(/obj/item/stinger = 1, /obj/item/stack/sheet/animalhide/weaver_chitin = 2, /obj/item/stack/sheet/sinew = 4, /obj/item/gem/ruby = 2)
 	melee_damage_lower = 15
 	melee_damage_upper = 25
 	pixel_x = -16
@@ -318,7 +318,7 @@
 
 /mob/living/simple_animal/hostile/yog_jungle/alpha_yellowjacket
 	name = "yellow jacket matriarch"
-	desc = "A large and aggressive creature with a massive stinger. It is very angry"
+	desc = "A large and aggressive creature with a massive stinger. It is very angry."
 	icon = 'yogstation/icons/mob/jungle64x64.dmi'
 	icon_state = "wasp"
 	icon_living = "wasp"
@@ -342,7 +342,7 @@
 	attack_sound = 'sound/voice/moth/scream_moth.ogg'
 	deathmessage = "rolls over, falling to the ground."
 	gold_core_spawnable = HOSTILE_SPAWN
-	butcher_results = list(/obj/item/stinger = 1)
+	butcher_results = list(/obj/item/stinger = 1, /obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/stack/sheet/sinew = 2, /obj/item/gem/topaz = 2)
 	loot = list()
 	crusher_loot = /obj/item/crusher_trophy/jungleland/wasp_head
 	pixel_x = -16 

--- a/yogstation/code/modules/jungleland/jungle_items.dm
+++ b/yogstation/code/modules/jungleland/jungle_items.dm
@@ -651,3 +651,12 @@
 	icon_state = "sheet-ivory"
 	grind_results = list(/datum/reagent/potassium = 10) //ivory is a bone
 
+/obj/item/gem/tarstone
+	name = "primal tarstone"
+	desc = "An incredibly dense and tough chunk of ancient tar. Millions of microscopic runes subtly line the surface, and probably make this artifact worth thousands."
+	icon = 'yogstation/icons/obj/jungle.dmi'
+	icon_state = "targem"
+	point_value = 3000
+	light_range = 3
+	light_power = 4
+	light_color = "#2d066d"

--- a/yogstation/code/modules/jungleland/jungle_megafauna.dm
+++ b/yogstation/code/modules/jungleland/jungle_megafauna.dm
@@ -34,7 +34,7 @@
 	do_footstep = TRUE
 	ranged_cooldown_time = 10 SECONDS
 	dodge_prob = 0
-	loot = list(/obj/item/clothing/head/yogs/tar_king_crown)
+	loot = list(/obj/item/clothing/head/yogs/tar_king_crown = 1, /obj/item/gem/tarstone = 1)
 	crusher_loot = list(/obj/item/crusher_trophy/jungleland/aspect_of_tar)
 	var/list/attack_adjustments = list()
 	var/last_done_attack = 0

--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -47,7 +47,7 @@
 	health = 60
 	spacewalk = TRUE
 	ranged = TRUE
-	loot = list(/obj/item/organ/regenerative_core/dryad,/obj/item/stack/sheet/bone = 3)
+	loot = list(/obj/item/organ/regenerative_core/dryad)
 	ranged_cooldown_time = 4 SECONDS
 	retreat_distance = 1
 	minimum_distance = 3
@@ -86,7 +86,7 @@
 	health = 120
 	spacewalk = TRUE
 	ranged = TRUE
-	loot = list (/obj/item/organ/regenerative_core/dryad/corrupted,/obj/item/stack/sheet/bone = 3)
+	loot = list (/obj/item/organ/regenerative_core/dryad/corrupted)
 	ranged_cooldown_time = 2 SECONDS
 	retreat_distance = 1
 	minimum_distance = 3
@@ -349,7 +349,7 @@
 	speak_chance = 0
 	taunt_chance = 0
 	turns_per_move = 0
-	butcher_results = list(/obj/item/stinger = 1,/obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/stack/sheet/sinew = 2)
+	butcher_results = list(/obj/item/stinger = 1,/obj/item/stack/sheet/animalhide/weaver_chitin = 1, /obj/item/stack/sheet/sinew = 2)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
@@ -462,7 +462,7 @@
 	attack_sound = 'sound/voice/moth/scream_moth.ogg'
 	deathmessage = "rolls over, falling to the ground."
 	gold_core_spawnable = HOSTILE_SPAWN
-	butcher_results = list(/obj/item/stinger = 1,/obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/stack/sheet/sinew = 2)
+	butcher_results = list(/obj/item/stinger = 1,/obj/item/stack/sheet/animalhide/weaver_chitin = 2, /obj/item/stack/sheet/sinew = 1)
 	loot = list()
 	alpha_type = /mob/living/simple_animal/hostile/yog_jungle/alpha_yellowjacket
 	var/charging = FALSE

--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -462,7 +462,7 @@
 	attack_sound = 'sound/voice/moth/scream_moth.ogg'
 	deathmessage = "rolls over, falling to the ground."
 	gold_core_spawnable = HOSTILE_SPAWN
-	butcher_results = list(/obj/item/stinger = 1,/obj/item/stack/sheet/animalhide/weaver_chitin = 2, /obj/item/stack/sheet/sinew = 1)
+	butcher_results = list(/obj/item/stinger = 1,/obj/item/stack/sheet/animalhide/weaver_chitin = 1, /obj/item/stack/sheet/sinew = 1, /obj/item/stack/sheet/bone = 1)
 	loot = list()
 	alpha_type = /mob/living/simple_animal/hostile/yog_jungle/alpha_yellowjacket
 	var/charging = FALSE

--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -526,7 +526,7 @@
 	icon_state = "emeraldspider"
 	icon_living = "emeraldspider"
 	icon_dead = "emeraldspider_dead"
-	butcher_results = list(/obj/item/stack/sheet/bone = 3, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/reagent_containers/food/snacks/meat/slab/spider = 2)
+	butcher_results = list(/obj/item/stack/sheet/bone = 4, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/reagent_containers/food/snacks/meat/slab/spider = 2)
 	loot = list()
 	attacktext = "bites"
 	gold_core_spawnable = HOSTILE_SPAWN

--- a/yogstation/code/modules/jungleland/kinetic_javelin.dm
+++ b/yogstation/code/modules/jungleland/kinetic_javelin.dm
@@ -161,12 +161,12 @@
 	javelin_item_state = "kinetic_javelin_blue"
 
 /obj/item/kinetic_javelin_core/blue/get_effect_description()
-	return "When charged, the next successfuly hit against an enemy unleashes a massive surge of electricity, targeting all exotic lifeforms." 
+	return "When charged, the next successful hit against an enemy unleashes a surge of electricity that targets all nearby exotic lifeforms." 
 
 /obj/item/kinetic_javelin_core/blue/charged_effect(mob/living/simple_animal/hostile/victim, obj/item/kinetic_javelin/javelin,mob/user)
 	for(var/mob/living/simple_animal/hostile/H in range(4,victim) - victim)
 		victim.Beam(H,"lightning[rand(1,12)]",time = 15)
-		H.adjustFireLoss(35)
+		H.adjustFireLoss(15)
 
 /obj/item/kinetic_javelin_core/red 
 	name = "Enraged Kinetic Javelin Core"


### PR DESCRIPTION
some changes to rebalance electrified core and loot based on my own thought, if you want them.


electrified javelin core damage reduced to 15 from 35
(core is far too strong, trivializes any group of mobs. Even with just fighting 2 mobs, you're outputting far more damage than an enraged core.)

removes bones from both dryad types
(its a plant spirit and already has good loot, the heart)

mosquito chitin reduced to 1 from 4 
(they're not hard to kill)

yellowjacket chitin reduced from 4 to 1, and sinew from 2 to 1, but they do drop 1 bone now.
(they're also not that hard to kill. Bone drop doesn't make much more sense than dryad but there does need to be another source of bones)

emerald spider drops 4 bones instead of 3
(make up a little for dryads not dropping them)

all alpha mobs get their original monster's butcher results about times 2 (if they didn't have it already), and 2 low level mining gems (worth 200 mining points each)

tar king drops a primal tarstone gem, which can be claimed and sold on the cargo shuttle for 3000 mining points.

and some spelling fixes