### PR TITLE
minor ruin tweaks

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungleland_dead_tartemple.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_dead_tartemple.dmm
@@ -34,10 +34,6 @@
 "al" = (
 /turf/template_noop,
 /area/template_noop)
-"am" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/dirt/jungleland/dying_forest,
-/area/ruin/unpowered/tar_temple)
 "an" = (
 /mob/living/simple_animal/hostile/tar/amalgamation,
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
@@ -174,6 +170,15 @@
 	},
 /turf/open/floor/plating/dirt/jungleland/obsidian,
 /area/ruin/unpowered/tar_temple)
+"ko" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/template_noop)
+"pW" = (
+/obj/effect/decal/remains/human,
+/obj/item/storage/backpack/satchel/explorer,
+/turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/ruin/unpowered/tar_temple)
 "rb" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -188,6 +193,10 @@
 /area/ruin/unpowered/tar_temple)
 "zB" = (
 /obj/item/ammo_casing/reusable/arrow/bamboo,
+/turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/ruin/unpowered/tar_temple)
+"Ci" = (
+/obj/item/clothing/suit/toggle/labcoat,
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/ruin/unpowered/tar_temple)
 "Du" = (
@@ -223,8 +232,19 @@
 	},
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/ruin/unpowered/tar_temple)
+"Hc" = (
+/obj/item/paper/crumpled{
+	info = "These temples appear to be some kind of places of worship, and all house some sort of crystal fragment. This temple appears especially odd, as it seems to resemble some sort of large arena, and the altar within seems especially peculiar, almost as if it is begging to be made complete with an offering. Many of the locals have refused to accompany us to these expeditions no matter our offers, and this one was especially frowned upon, but we do have a few escorts in case anything goes wrong..."
+	},
+/turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/ruin/unpowered/tar_temple)
 "Hd" = (
 /obj/structure/stone_tile,
+/turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/ruin/unpowered/tar_temple)
+"Hs" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/mask/gas/explorer,
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/ruin/unpowered/tar_temple)
 "JX" = (
@@ -239,6 +259,10 @@
 /obj/item/melee/spear/bamboospear,
 /turf/open/floor/plating/dirt/jungleland/dying_forest,
 /area/ruin/unpowered/tar_temple)
+"Lw" = (
+/obj/item/flashlight/seclite,
+/turf/open/floor/plating/dirt/jungleland/dying_forest,
+/area/template_noop)
 "Nk" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -820,7 +844,7 @@ aO
 ah
 aO
 az
-am
+pW
 aO
 Fu
 au
@@ -912,8 +936,8 @@ aO
 aO
 aO
 aO
-aO
-am
+Ci
+Hs
 au
 aO
 at
@@ -927,7 +951,7 @@ aY
 aY
 aw
 ai
-ai
+ko
 ai
 ai
 "}
@@ -954,7 +978,7 @@ aO
 aO
 aO
 aO
-aO
+Hc
 au
 aO
 aO
@@ -967,7 +991,7 @@ aw
 aY
 aY
 aw
-ai
+Lw
 ai
 ai
 ai

--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_xenos.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_xenos.dmm
@@ -194,10 +194,6 @@
 	},
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
-"gI" = (
-/obj/structure/sign/warning,
-/turf/closed/indestructible/rock/wood,
-/area/template_noop)
 "kb" = (
 /obj/effect/mine/stun,
 /turf/open/floor/plating/dirt/jungleland/jungle,
@@ -275,6 +271,12 @@
 /obj/item/storage/box/mre/menu3,
 /turf/open/floor/plating/dirt/jungleland/jungle,
 /area/ruin/unpowered)
+"MY" = (
+/obj/structure/sign/warning{
+	desc = "A warning sign denoting landmines ahead."
+	},
+/turf/closed/indestructible/rock/wood,
+/area/template_noop)
 "Ou" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -369,7 +371,7 @@ aP
 aP
 aP
 aP
-aP
+aS
 aP
 aP
 aP
@@ -395,12 +397,12 @@ aV
 aV
 aV
 aV
-aP
-aP
-ax
-aP
-aS
-aP
+uP
+uP
+ay
+ay
+uP
+uP
 aV
 aV
 aV
@@ -429,7 +431,7 @@ aP
 aW
 ai
 aP
-aP
+ax
 aP
 aV
 am
@@ -585,9 +587,9 @@ aJ
 av
 aP
 aP
-ay
-ax
 aP
+ax
+uP
 aP
 aH
 "}
@@ -615,9 +617,9 @@ aP
 aI
 aP
 aP
-ay
 aP
 aP
+uP
 aP
 aH
 "}
@@ -793,8 +795,8 @@ aP
 aY
 ap
 aP
-aP
-aP
+ay
+ay
 aV
 aV
 aV
@@ -825,7 +827,7 @@ ay
 aP
 aP
 aP
-ay
+uP
 aP
 aP
 aP
@@ -855,7 +857,7 @@ aP
 aP
 aj
 aP
-ay
+uP
 aP
 aP
 aP
@@ -1099,7 +1101,7 @@ ae
 ae
 ae
 ae
-gI
+MY
 "}
 (27,1,1) = {"
 aP

--- a/_maps/RandomRuins/JungleRuins/jungleland_swamp_oldhut.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_swamp_oldhut.dmm
@@ -1,82 +1,81 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"b" = (
-/obj/item/storage/bag/medpouch,
-/turf/open/floor/wood,
+"a" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
-"h" = (
+"d" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/leather,
 /obj/item/stack/medical/aloe,
 /obj/item/stack/medical/aloe,
-/turf/open/floor/wood,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 "l" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/wood,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/wood/jungle,
+/area/ruin/unpowered)
+"n" = (
+/mob/living/simple_animal/pet/cat,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 "q" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/wood,
+/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 "t" = (
-/mob/living/simple_animal/pet/cat,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"u" = (
-/obj/effect/decal/remains/human,
-/obj/item/clothing/head/witchwig,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/wood,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 "w" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/mortar,
-/obj/item/pestle,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"x" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bottle{
-	name = "potion"
-	},
-/turf/open/floor/wood,
+/obj/item/storage/bag/medpouch,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 "y" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/unpowered)
+"C" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/head/witchwig,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/jungle,
+/area/ruin/unpowered)
 "D" = (
-/obj/structure/mineral_door/wood,
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating/dirt/jungleland/toxic_pit,
-/area/ruin/unpowered)
-"F" = (
-/obj/structure/table/wood,
-/obj/item/stack/medical/poultice,
-/obj/item/stack/medical/poultice,
-/obj/item/stack/medical/poultice,
-/turf/open/floor/wood,
-/area/ruin/unpowered)
-"H" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bowl/mushroom_bowl,
-/turf/open/floor/wood,
+/turf/open/floor/wood/jungle,
+/area/ruin/unpowered)
+"J" = (
+/obj/structure/mineral_door/wood,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 "M" = (
 /turf/template_noop,
 /area/template_noop)
-"P" = (
-/obj/item/reagent_containers/glass/bowl/mushroom_bowl,
-/turf/open/floor/wood,
+"O" = (
+/obj/structure/table/wood,
+/obj/item/stack/medical/poultice,
+/obj/item/stack/medical/poultice,
+/obj/item/stack/medical/poultice,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
-"V" = (
+"S" = (
 /obj/item/storage/bag/ore/holding,
-/turf/open/floor/wood,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
-"Z" = (
-/turf/open/floor/wood,
+"T" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bottle{
+	name = "potion"
+	},
+/turf/open/floor/wood/jungle,
+/area/ruin/unpowered)
+"U" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/wood/jungle,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -119,10 +118,10 @@ M
 M
 M
 y
-w
-V
-Z
-x
+a
+S
+t
+T
 y
 M
 M
@@ -131,10 +130,10 @@ M
 M
 M
 y
+l
+t
+C
 q
-Z
-u
-P
 y
 M
 M
@@ -143,11 +142,11 @@ M
 M
 M
 y
-l
+U
+n
 t
-Z
-b
-D
+w
+J
 M
 M
 "}
@@ -155,10 +154,10 @@ M
 M
 M
 y
-h
-Z
-P
-Z
+d
+t
+q
+t
 y
 M
 M
@@ -167,10 +166,10 @@ M
 M
 M
 y
-H
-Z
-Z
-F
+D
+t
+t
+O
 y
 M
 M


### PR DESCRIPTION
tweaks a few ruins.

swamp hut has jungle wood flooring instead of standard wood flooring and a air blocker (lower chances of atmos shenanigans)

xenos ruin has more cover to make it slightly less likely the xenos get killed by mobs before you come in.

dying jungle tar temple has a flavor note and a few minor things like a gasmask and labcoat. Flavor note gives a hint on what to do with the tar crystals and where to get them, and some backstory on what is going on.

flavor note text: "These temples appear to be some kind of places of worship, and all house some sort of crystal fragment. This temple appears especially odd, as it seems to resemble some sort of large arena, and the altar within seems especially peculiar, almost as if it is begging to be made complete with an offering. Many of the locals have refused to accompany us to these expeditions no matter our offers, and this one was especially frowned upon, but we do have a few escorts in case anything goes wrong..."